### PR TITLE
single step wizard related modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## next
 
+## 1.2.0
+* New showHeaderTabs prop that can be used to hide tabs in the header (e.g. in a single step wizard)
+* Footer's page indicators/navigation arrows are now hidden if wizard has only one step
+* Step name is no longer a required prop, because it is possible to hide header tabs altogether
 
 ## 1.1.1
 * Fixed obsolete class names: oc-mandatory and oc-mandatory-error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## next
-
-## 1.2.0
 * New showHeaderTabs prop that can be used to hide tabs in the header (e.g. in a single step wizard)
 * Footer's page indicators/navigation arrows are now hidden if wizard has only one step
 * Step name is no longer a required prop, because it is possible to hide header tabs altogether

--- a/src/README.md
+++ b/src/README.md
@@ -23,6 +23,7 @@ localizationTexts | map | { save: 'Save', cancel: 'Cancel', saved: 'Saved' } | L
 save | function | required | Callback function called, when the wizard is saved
 disableSave | bool | false | Disable the Save button
 showPageIndicator | bool | true | Sign of page indicator showing
+showHeaderTabs | bool | true | Show tabs in the header
 steps | array | required | Steps of the wizard
 activeStep | number | 0 | Index of the active step. You can also set initial active step via URL parameter 'initialStep', e.g. http://localhost/wizard/?initialStep=stepId
 showSaveSuccess | bool | false | If true, shows a success message in the footer
@@ -36,7 +37,7 @@ component | element | required | Step content
 hasRequiredProps | bool | false | Sign of required fields in the content
 hasRequiredPropsErrors | bool | false | Sign of invalidated required props
 id | [number, string] | required | Step id
-name | [element, string] | required | Step name
+name | [element, string] | undefined | Step name
 
 ## Code example
 

--- a/src/components/wizard-footer.component.jsx
+++ b/src/components/wizard-footer.component.jsx
@@ -20,7 +20,7 @@ export default class WizardFooter extends React.PureComponent {
       cancel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     }).isRequired,
     steps: PropTypes.arrayOf(PropTypes.shape({
-      name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+      name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
       component: PropTypes.node.isRequired,
     })).isRequired,
     selectPage: PropTypes.func.isRequired,
@@ -37,7 +37,7 @@ export default class WizardFooter extends React.PureComponent {
   };
 
   getIndicators = () => (
-    this.props.steps.map((step, i) => {
+    this.props.steps.length > 1 && this.props.steps.map((step, i) => {
       if (i === this.props.currentStep) {
         return <span key={step.id} className="tab-indicator tab-highlight" />;
       }
@@ -61,13 +61,14 @@ export default class WizardFooter extends React.PureComponent {
           }
           <div id="bottom-buttons">
             <section>
+              {steps.length > 1 &&
               <Button
                 disabled={currentStep === 0}
                 id="previous-step"
                 onClick={event => this.props.selectPage(event, currentStep - 1)}
               >
                 <FaCaretLeft />
-              </Button>
+              </Button>}
             </section>
             <section>
               <Button
@@ -87,22 +88,23 @@ export default class WizardFooter extends React.PureComponent {
               </Button>
             </section>
             <section>
+              {steps.length > 1 &&
               <Button
                 disabled={currentStep === steps.length - 1}
                 id="next-step"
                 onClick={event => this.props.selectPage(event, currentStep + 1)}
               >
                 <FaCaretRight />
-              </Button>
+              </Button>}
             </section>
           </div>
         </section>
         <section className="right column">
           {showSaveSuccess &&
-            <div className="save-success-container">
-              <FaCheck className="save-success-indicator" />
-              {localizationTexts.saved}
-            </div>}
+          <div className="save-success-container">
+            <FaCheck className="save-success-indicator" />
+            {localizationTexts.saved}
+          </div>}
         </section>
       </div>
     );

--- a/src/components/wizard-header.component.jsx
+++ b/src/components/wizard-header.component.jsx
@@ -16,10 +16,11 @@ export default class WizardHeader extends React.PureComponent {
       hasRequiredProps: PropTypes.bool,
       hasRequiredPropsErrors: PropTypes.bool,
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-      name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+      name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     })).isRequired,
     selectPage: PropTypes.func.isRequired,
     currentStep: PropTypes.number.isRequired,
+    showHeaderTabs: PropTypes.bool.isRequired,
   }
 
   constructor() {
@@ -85,12 +86,15 @@ export default class WizardHeader extends React.PureComponent {
   render() {
     return (
       <div id="wizard-header">
-        { this.state.showScroll &&
-          <button className="hidden-button" onClick={this.scrollLeft}>
-            <FaCaretLeft />
-          </button> }
-        <ul ref={(node) => { this.scrollbar = node; }}>
-          {this.props.steps.map((step, i) => {
+        {this.state.showScroll &&
+        <button className="hidden-button" onClick={this.scrollLeft}>
+          <FaCaretLeft />
+        </button>}
+        <ul ref={(node) => {
+          this.scrollbar = node;
+        }}
+        >
+          {this.props.showHeaderTabs && this.props.steps.map((step, i) => {
             let labelClassName = '';
             if (step.hasRequiredPropsErrors) {
               labelClassName = 'oc-ui-mandatory-error';
@@ -101,7 +105,9 @@ export default class WizardHeader extends React.PureComponent {
               <li
                 key={step.id}
                 className={i === this.props.currentStep ? 'doing' : ''}
-                ref={(node) => { this.tabElements[i] = node; }}
+                ref={(node) => {
+                  this.tabElements[i] = node;
+                }}
               >
                 <a
                   id={step.id}
@@ -123,10 +129,10 @@ export default class WizardHeader extends React.PureComponent {
             );
           })}
         </ul>
-        { this.state.showScroll &&
-          <button className="hidden-button" onClick={this.scrollRight}>
-            <FaCaretRight />
-          </button> }
+        {this.state.showScroll &&
+        <button className="hidden-button" onClick={this.scrollRight}>
+          <FaCaretRight />
+        </button>}
       </div>
     );
   }

--- a/src/components/wizard.component.jsx
+++ b/src/components/wizard.component.jsx
@@ -60,6 +60,7 @@ export default class Wizard extends React.PureComponent {
       <div id="wizard-pages">
         <WizardHeader
           steps={this.props.steps}
+          showHeaderTabs={this.props.showHeaderTabs}
           currentStep={this.state.currentStep}
           selectPage={this.selectPage}
         />
@@ -86,6 +87,7 @@ export default class Wizard extends React.PureComponent {
 Wizard.defaultProps = {
   activeStep: 0,
   showPageIndicator: true,
+  showHeaderTabs: true,
   localizationTexts: {
     save: 'Save',
     cancel: 'Close',
@@ -107,7 +109,7 @@ Wizard.propTypes = {
     hasRequiredProps: PropTypes.bool,
     hasRequiredPropsErrors: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    name: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   })).isRequired,
   localizationTexts: PropTypes.shape({
     save: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
@@ -116,6 +118,7 @@ Wizard.propTypes = {
   }),
   activeStep: PropTypes.number,
   showPageIndicator: PropTypes.bool,
+  showHeaderTabs: PropTypes.bool,
   showSaveSuccess: PropTypes.bool,
   onStepChange: PropTypes.func,
 };


### PR DESCRIPTION
* New showHeaderTabs prop that can be used to hide tabs in the header (e.g. in a single step wizard)
* Footer's page indicators/navigation arrows are now hidden if wizard has only one step
* Step name is no longer a required prop, because it is possible to hide header tabs altogether